### PR TITLE
make gui path generalized

### DIFF
--- a/src/Mu2eEventDisplay_module.cc
+++ b/src/Mu2eEventDisplay_module.cc
@@ -463,7 +463,7 @@ namespace mu2e
       frame_->makeGeometryScene(eveMng_, geomOpts, gdmlname_);
 
       //add path to the custom GUI code here, this overrides ROOT GUI
-      eveMng_->AddLocation("mydir/", "EventDisplay/CustomGUIv2");
+      eveMng_->AddLocation("mydir/", configFile("EventDisplay/CustomGUIv2"));
       eveMng_->SetDefaultHtmlPage("file:mydir/eventDisplay.html");
 
       // InitGuiInfo() cont'd


### PR DESCRIPTION
If this dir is found by MU2E_SEARCH_PATH, then the user can cd to any directory and still operate the display correctly.  This is also needed for the spack build since, unlike muse, the build directory is not usually the same as the default dir.