### PR TITLE
Display CRV

### DIFF
--- a/examples/nominal_example.fcl
+++ b/examples/nominal_example.fcl
@@ -22,7 +22,7 @@ physics.analyzers.Mu2eEventDisplay.showCRV : true
 physics.analyzers.Mu2eEventDisplay.showPS : false
 physics.analyzers.Mu2eEventDisplay.showTS : false
 physics.analyzers.Mu2eEventDisplay.showDS : false
-physics.analyzers.Mu2eEventDisplay.addCRVBars : false
+physics.analyzers.Mu2eEventDisplay.addCRVBars : true
 physics.analyzers.Mu2eEventDisplay.addKalInter : true
 physics.analyzers.Mu2eEventDisplay.addCrystalHits : true
 physics.analyzers.Mu2eEventDisplay.filler.addHelixSeeds : false
@@ -30,7 +30,7 @@ physics.analyzers.Mu2eEventDisplay.filler.addKalSeeds : true
 physics.analyzers.Mu2eEventDisplay.filler.addClusters : true
 physics.analyzers.Mu2eEventDisplay.filler.addHits : false #  adds ComboHits
 physics.analyzers.Mu2eEventDisplay.filler.addCrvClusters : true
-physics.analyzers.Mu2eEventDisplay.filler.addCrvHits : false
+physics.analyzers.Mu2eEventDisplay.filler.addCrvHits : true
 physics.analyzers.Mu2eEventDisplay.filler.addTimeClusters : false
 physics.analyzers.Mu2eEventDisplay.addTrkStrawHits : true
 physics.analyzers.Mu2eEventDisplay.filler.addCosmicTrackSeeds : false

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -22,8 +22,8 @@ Mu2eEventDisplay : {
     filler : {
       diagLevel : 0
       ComboHitCollection : ["makeSH"]
-      CrvRecoPulseCollection : ["SelectRecoMC"]
-      CrvCoincidenceClusterCollection : ["SelectRecoMC:CrvCoincidenceClusterFinder" ]
+      CrvRecoPulseCollection : ["SelectReco"]
+      CrvCoincidenceClusterCollection : ["SelectReco:CrvCoincidenceClusterFinder" ]
       TimeClusterCollection : ["MHDeM"]
       CaloDigiCollection : ["CaloDigiMaker"]
       CaloClusterCollection : ["CaloClusterMaker"]


### PR DESCRIPTION
Turn on CRV display. Update to new provenance of CRV components. Note this latter is not backwards-compatible with existing datasets.