### PR TITLE
Drop Trigger CaloClusters to prevent an exception

### DIFF
--- a/examples/nominal_example.fcl
+++ b/examples/nominal_example.fcl
@@ -61,4 +61,8 @@ services.TFileService.fileName: "/dev/null"
 #  "1202:636:337031",
 #  "1202:648:370322" ]
 #
-#
+
+source.inputCommands: ["keep *",
+    "drop mu2e::CaloClusters_CaloClusterFast_*_*"
+    ]
+


### PR DESCRIPTION
This addresses a problem displaying MDC2020au and MDC2020aw reco output. A code fix is eventually needed.