### PR TITLE
Added Tracker Planes Y v/s Z view

### DIFF
--- a/examples/extracted_MDC2025.fcl
+++ b/examples/extracted_MDC2025.fcl
@@ -46,6 +46,7 @@ physics.analyzers.Mu2eEventDisplay.filler.addCrvRecoPulse : false
 physics.analyzers.Mu2eEventDisplay.filler.addCaloDigis : false
 physics.analyzers.Mu2eEventDisplay.filler.addClusters : false
 physics.analyzers.Mu2eEventDisplay.filler.addKalSeeds : true
+physics.analyzers.Mu2eEventDisplay.filler.addTrackerHist : true
 physics.analyzers.Mu2eEventDisplay.extracted : true
 physics.analyzers.Mu2eEventDisplay.specifyTag : false
 

--- a/fcl/extracted.fcl
+++ b/fcl/extracted.fcl
@@ -21,8 +21,8 @@ Mu2eEventDisplay.filler.addSimParts : false
 Mu2eEventDisplay.addTrkStrawHits : true
 Mu2eEventDisplay.addTrkCaloHits : true
 Mu2eEventDisplay.filler.addCosmicTrackSeeds : false
- Mu2eEventDisplay.filler.addMCTraj : true
- Mu2eEventDisplay.filler.addTrackerHist : false
+Mu2eEventDisplay.filler.addMCTraj : true
+Mu2eEventDisplay.filler.addTrackerHist : true
 Mu2eEventDisplay.filler.addHelixSeeds : false
 Mu2eEventDisplay.specifyTag : false
 

--- a/fcl/extracted.fcl
+++ b/fcl/extracted.fcl
@@ -21,7 +21,8 @@ Mu2eEventDisplay.filler.addSimParts : false
 Mu2eEventDisplay.addTrkStrawHits : true
 Mu2eEventDisplay.addTrkCaloHits : true
 Mu2eEventDisplay.filler.addCosmicTrackSeeds : false
-Mu2eEventDisplay.filler.addMCTraj : true
+ Mu2eEventDisplay.filler.addMCTraj : true
+ Mu2eEventDisplay.filler.addTrackerHist : false
 Mu2eEventDisplay.filler.addHelixSeeds : false
 Mu2eEventDisplay.specifyTag : false
 

--- a/fcl/nominal.fcl
+++ b/fcl/nominal.fcl
@@ -20,7 +20,8 @@ Mu2eEventDisplay.filler.addSimParts : false
 Mu2eEventDisplay.addTrkStrawHits : true
 Mu2eEventDisplay.addTrkCaloHits : true
 Mu2eEventDisplay.filler.addCosmicTrackSeeds : false
-Mu2eEventDisplay.filler.addMCTraj : true
+ Mu2eEventDisplay.filler.addMCTraj : true
+ Mu2eEventDisplay.filler.addTrackerHist : false
 Mu2eEventDisplay.filler.addHelixSeeds : false
 Mu2eEventDisplay.specifyTag : false
 

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -49,7 +49,8 @@ Mu2eEventDisplay : {
       addClusters : true
       addKalSeeds : true
       addCosmicTrackSeeds : false
-      addMCTraj : true
+       addMCTraj : true
+       addTrackerHist : false
       addSurfSteps : true
       addSimParts : false
       addHelixSeeds : false

--- a/inc/CollectionFiller.hh
+++ b/inc/CollectionFiller.hh
@@ -88,6 +88,7 @@ namespace mu2e{
             fhicl::Atom<bool> addMCTraj{Name("addMCTraj"), Comment("set to add MCTrajectories"),false};
             fhicl::Atom<bool> addSurfSteps{Name("addSurfSteps"), Comment("set to add SurfaceStep MC"),false};
             fhicl::Atom<bool> addSimParts{Name("addSimParts"), Comment("set to add SimParticles MC"),false};
+            fhicl::Atom<bool> addTrackerHist{Name("addTrackerHist"), Comment("set to add tracker histogram"),false};
             
             // Global flag to attempt retrieval of all collections found in the event
             fhicl::Atom<bool> FillAll{Name("FillAll"), Comment("to see all available products"), false};
@@ -126,9 +127,9 @@ namespace mu2e{
         art::Run *_run;
         
         // --- Boolean Control Flags (Copied from FHiCL Config) ---
-        bool addHits_, addBkgClusters_, addCrvRecoPulse_, addCrvClusters_, addCrvTrack_, addTimeClusters_, addTrkHits_, addCaloDigis_, 
-             addClusters_, addHelixSeeds_, addKalSeeds_, addCosmicTrackSeeds_, addMCTraj_,
-             addSurfSteps_, addSimParts_, FillAll_;
+         bool addHits_, addBkgClusters_, addCrvRecoPulse_, addCrvClusters_, addCrvTrack_, addTimeClusters_, addTrkHits_, addCaloDigis_, 
+              addClusters_, addHelixSeeds_, addKalSeeds_, addCosmicTrackSeeds_, addMCTraj_,
+              addSurfSteps_, addSimParts_, addTrackerHist_, FillAll_;
              
         // --- Collection Retrieval Methods ---
         

--- a/inc/MainWindow.hh
+++ b/inc/MainWindow.hh
@@ -18,9 +18,21 @@
 #include "TTimer.h"
 #include "TGeoMatrix.h"
 #include "TError.h"
+#include <TPad.h>
+#include <TCanvas.h>
+#include <TBufferJSON.h>
+#include <TBase64.h>
 #include <TApplication.h>
 #include <TSystem.h>
 #include <TGTextEntry.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TRandom3.h>
+#include <TBox.h>
+#include <TEllipse.h>
+#include <TLine.h>
+#include <TLatex.h>
+#include <TGraph.h>
 #include <ROOT/REveGeoShape.hxx>
 #include <ROOT/REveScene.hxx>
 #include <ROOT/REveViewer.hxx>
@@ -44,6 +56,13 @@
 #include "EventDisplay/inc/DataInterface.hh"
 #include "EventDisplay/inc/MCInterface.hh"
 #include "Offline/StoppingTargetGeom/inc/StoppingTarget.hh"
+#include "Offline/CalorimeterGeom/inc/DiskCalorimeter.hh"
+#include "Offline/CalorimeterGeom/inc/Disk.hh"
+#include "Offline/CalorimeterGeom/inc/Crystal.hh"
+#include "Offline/TrackerGeom/inc/Panel.hh"
+#include "Offline/TrackerGeom/inc/Plane.hh"
+#include "Offline/TrackerGeom/inc/Straw.hh"
+#include "Offline/TrackerGeom/inc/Tracker.hh"
 
 #include <utility>
 namespace REX = ROOT::Experimental;
@@ -169,6 +188,9 @@ namespace mu2e {
             void projectScenes(REX::REveManager *eveMng, bool geomp, bool eventp);
             void projectEvents(REX::REveManager *eveMng);
             void maketable(REX::REveManager *eveMng);
+            void createHistogramView();
+            void redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol);
+            void drawTrackerStation(const mu2e::KalSeedPtrCollection* seedcol);
 
             REX::REveProjectionManager *mngTrackerXY = nullptr;
             REX::REveProjectionManager *mngXYCaloDisk0 = nullptr;
@@ -182,6 +204,9 @@ namespace mu2e {
             REX::REveViewer *XYCaloDisk0View = nullptr;
             REX::REveViewer *XYCaloDisk1View = nullptr;
             REX::REveViewer *rhoZView = nullptr;
+
+            REX::REvePointSet* fCanvasHolder{nullptr};
+            TCanvas* fCanvas{nullptr};
 
             #else
                 ClassDef(MainWindow, 0);

--- a/inc/MainWindow.hh
+++ b/inc/MainWindow.hh
@@ -192,7 +192,7 @@ namespace mu2e {
             
             TrackerCalo2DViews *fTrackerCalo2DViews = nullptr;
 
-            TrackerCalo2DViews *fTrackerCalo2DViews = nullptr;
+            REX::REveProjectionManager *mngTrackerXY   = nullptr;
             REX::REveProjectionManager *mngXYCaloDisk0 = nullptr;
             REX::REveProjectionManager *mngXYCaloDisk1 = nullptr;
             REX::REveProjectionManager *mngRhoZ   = nullptr;
@@ -205,8 +205,8 @@ namespace mu2e {
             REX::REveViewer *XYCaloDisk1View = nullptr;
             REX::REveViewer *rhoZView = nullptr;
 
-            REX::REvePointSet* fCanvasHolder{nullptr};
-            TCanvas* fCanvas{nullptr};
+      /*REX::REvePointSet* fCanvasHolder{nullptr};
+        TCanvas* fCanvas{nullptr};*/
 
             #else
                 ClassDef(MainWindow, 0);

--- a/inc/MainWindow.hh
+++ b/inc/MainWindow.hh
@@ -53,6 +53,7 @@
 #include <ROOT/REveViewContext.hxx>
 #include "art/Framework/Principal/Event.h"
 #include "EventDisplay/inc/DataCollections.hh"
+#include "EventDisplay/inc/TrackerCalo2DViews.hh"
 #include "EventDisplay/inc/DataInterface.hh"
 #include "EventDisplay/inc/MCInterface.hh"
 #include "Offline/StoppingTargetGeom/inc/StoppingTarget.hh"
@@ -188,11 +189,10 @@ namespace mu2e {
             void projectScenes(REX::REveManager *eveMng, bool geomp, bool eventp);
             void projectEvents(REX::REveManager *eveMng);
             void maketable(REX::REveManager *eveMng);
-            void createHistogramView();
-            void redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol);
-            void drawTrackerStation(const mu2e::KalSeedPtrCollection* seedcol);
+            
+            TrackerCalo2DViews *fTrackerCalo2DViews = nullptr;
 
-            REX::REveProjectionManager *mngTrackerXY = nullptr;
+            TrackerCalo2DViews *fTrackerCalo2DViews = nullptr;
             REX::REveProjectionManager *mngXYCaloDisk0 = nullptr;
             REX::REveProjectionManager *mngXYCaloDisk1 = nullptr;
             REX::REveProjectionManager *mngRhoZ   = nullptr;

--- a/inc/MainWindow.hh
+++ b/inc/MainWindow.hh
@@ -151,14 +151,15 @@ namespace mu2e {
       bool addTrkHits = false; // legacy
       bool addMCTrajectories = false;
       bool addSurfaceSteps = false;
-      bool addSimParts = false;
-      bool addTrkErrBar = true;
+       bool addSimParts = false;
+       bool addTrackerHist = false;
+       bool addTrkErrBar = true;
       bool addCrystalDraw = false;
       bool addCrvBars = true;
       DrawOptions(){};
 
-       DrawOptions(bool cosmictracks, bool helices, bool tracks, bool calodigis, bool clusters, bool combohits, bool bkgclusters, bool crv, bool crvclu, bool crvtrack, bool timeclusters, bool trkhits, bool mctraj, bool surfsteps, bool simparts, bool errbar, bool crys, bool crvbars)
-       : addCosmicTracks(cosmictracks), addHelices(helices), addTracks(tracks), addCaloDigis(calodigis), addClusters(clusters), addComboHits(combohits), addBkgClusters(bkgclusters), addCrvRecoPulse(crv), addCrvClusters(crvclu), addCrvTrack(crvtrack), addTimeClusters(timeclusters), addTrkHits(trkhits), addMCTrajectories(mctraj), addSurfaceSteps(surfsteps), addSimParts(simparts), addTrkErrBar(errbar), addCrystalDraw(crys), addCrvBars(crvbars) {};
+        DrawOptions(bool cosmictracks, bool helices, bool tracks, bool calodigis, bool clusters, bool combohits, bool bkgclusters, bool crv, bool crvclu, bool crvtrack, bool timeclusters, bool trkhits, bool mctraj, bool surfsteps, bool simparts, bool trackerhist, bool errbar, bool crys, bool crvbars)
+        : addCosmicTracks(cosmictracks), addHelices(helices), addTracks(tracks), addCaloDigis(calodigis), addClusters(clusters), addComboHits(combohits), addBkgClusters(bkgclusters), addCrvRecoPulse(crv), addCrvClusters(crvclu), addCrvTrack(crvtrack), addTimeClusters(timeclusters), addTrkHits(trkhits), addMCTrajectories(mctraj), addSurfaceSteps(surfsteps), addSimParts(simparts), addTrackerHist(trackerhist), addTrkErrBar(errbar), addCrystalDraw(crys), addCrvBars(crvbars) {};
 
      };
 

--- a/inc/TrackerCalo2DViews.hh
+++ b/inc/TrackerCalo2DViews.hh
@@ -2,6 +2,7 @@
 #define TrackerCalo2DViews_hh
 
 #include <TCanvas.h>
+#include <TColor.h>
 #include <ROOT/REvePointSet.hxx>
 #include <ROOT/REveViewer.hxx>
 #include <ROOT/REveManager.hxx>

--- a/inc/TrackerCalo2DViews.hh
+++ b/inc/TrackerCalo2DViews.hh
@@ -1,0 +1,31 @@
+#ifndef TrackerCalo2DViews_hh
+#define TrackerCalo2DViews_hh
+
+#include <TCanvas.h>
+#include <ROOT/REvePointSet.hxx>
+#include <ROOT/REveViewer.hxx>
+#include <ROOT/REveManager.hxx>
+#include <ROOT/REveScene.hxx>
+#include "Offline/RecoDataProducts/inc/KalSeed.hh"
+
+namespace REX = ROOT::Experimental;
+
+namespace mu2e {
+
+class TrackerCalo2DViews {
+public:
+    TrackerCalo2DViews();
+    virtual ~TrackerCalo2DViews();
+
+    void createHistogramView();
+    void drawTrackerStation(const mu2e::KalSeedPtrCollection* seedcol);
+    void redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol);
+
+private:
+    REX::REvePointSet* fCanvasHolder{nullptr};
+    TCanvas* fCanvas{nullptr};
+};
+
+} // namespace mu2e
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ cet_make_library(
     SOURCE
       CollectionFiller.cc
       DataInterface.cc
+      TrackerCalo2DViews.cc
       EventDisplayManager.cc
       GUI.cc
       MCInterface.cc

--- a/src/CollectionFiller.cc
+++ b/src/CollectionFiller.cc
@@ -36,6 +36,7 @@ namespace mu2e{
     addMCTraj_(conf.addMCTraj()),
     addSurfSteps_(conf.addSurfSteps()),
     addSimParts_(conf.addSimParts()),
+    addTrackerHist_(conf.addTrackerHist()),
     FillAll_(conf.FillAll())
   {}
 

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -718,6 +718,91 @@ void MainWindow::projectEvents(REX::REveManager *eveMng)
   }
 }
 
+void MainWindow::createHistogramView(){
+  auto &evMng = *ROOT::Experimental::gEve;
+  auto histScene = evMng.SpawnNewScene("Histograms", "Histogram Scene");
+  fCanvasHolder = new ROOT::Experimental::REvePointSet("CanvasData");
+  histScene->AddElement(fCanvasHolder);
+  fCanvas = new TCanvas("Mu2eCanvas", "Mu2e stats", 800, 600);
+  auto canvasViewer = evMng.SpawnNewViewer("Histogram viewer", "Mu2e Histogram");
+  canvasViewer->AddScene(histScene);
+}
+
+void MainWindow::drawTrackerStation(const mu2e::KalSeedPtrCollection* seedcol){
+  if (!fCanvas || !fCanvasHolder) return;
+  fCanvas->cd();
+  fCanvas->Clear();
+  mu2e::GeomHandle<mu2e::Tracker> tracker;
+  int planeId = 22;
+  int panelId = 5;
+  const mu2e::Plane& plane = tracker->getPlane(planeId);
+  const mu2e::Panel& panel = plane.getPanel(panelId);
+  TPad* pad = new TPad("p_0_0", "First Panel", 0.05, 0.05, 0.95, 0.95);
+  pad->Draw();
+  pad->cd();
+  std::string frameTitle = "Plane" + std::to_string(planeId) + "Panel" + std::to_string(panelId) + "YZ view; Z [mm]; Y [mm]";
+  TH2F* frame = new TH2F("frame", frameTitle.c_str(), 100, -20, 20, 100, -200, 200);
+  frame->SetStats(0);
+  frame->Draw();
+  std::map<mu2e::StrawId, const mu2e::TrkStrawHitSeed*> hitDataMap;
+  if(seedcol != nullptr){
+    for (auto const& kseedptr : *seedcol){
+     const mu2e::KalSeed& kseed = *kseedptr; 
+      for (auto const& hit : kseed.hits()){
+        //hitStrawIds.insert(hit.strawId());
+        hitDataMap[hit.strawId()] = &hit;
+        std::cout<<"Hit straw ID = "<<hit.strawId()<<std::endl;
+      }
+    }
+  }
+  double strawRadius = tracker->strawProperties()._strawOuterRadius;
+  for (size_t iStraw=0; iStraw < panel.nStraws(); ++iStraw){
+    const mu2e::Straw& straw = panel.getStraw(iStraw);
+    CLHEP::Hep3Vector pos_l = panel.dsToPanel()*straw.getMidPoint();
+    std::cout<<"iStraw = "<<iStraw<<" pos_l x = "<<pos_l.x()<<" y = "<<pos_l.y()<<" z = "<<pos_l.z()<<" radius = "<<strawRadius<<" ID = "<<straw.id()<<std::endl;
+    TEllipse *circ = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
+    circ->SetLineColor(kGray+2);
+    circ->SetFillStyle(0);
+    circ->Draw();
+    //if(hitStrawIds.find(straw.id()) != hitStrawIds.end()){
+    if(hitDataMap.count(straw.id())){
+      const auto* hit = hitDataMap[straw.id()];
+      TEllipse *hitcirc = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
+      hitcirc->SetLineColor(kBlack);
+      hitcirc->SetFillStyle(0);
+      hitcirc->Draw();
+      double rdrift = hit->driftRadius();
+      TEllipse *rcirc = new TEllipse(pos_l.z(), pos_l.y(), rdrift, rdrift);
+      rcirc->SetLineColor(kRed);
+      rcirc->SetFillStyle(0);
+      rcirc->Draw();
+      double sz = pos_l.z();
+      double sy = pos_l.y();
+      TGraph *g = new TGraph(1, &sz, &sy);
+      g->SetMarkerColorAlpha(kWhite,0);
+      g->SetName(Form("Straw %d: %.2f MeV",straw.id().getStraw(), hit->energyDep()));
+      g->Draw("P SAME");
+    }
+  }
+  TLatex *tex = new TLatex();
+  tex->SetNDC();
+  tex->SetTextSize(0.04);
+  tex->DrawLatex(0.7, 0.92, Form("Plane %d : Panel %d", planeId, panelId));
+  pad->Modified();
+  pad->Update();
+}
+
+void MainWindow::redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol){
+  if (!fCanvas || !fCanvasHolder) return;
+  drawTrackerStation(seedcol);
+  fCanvas->Modified();
+  fCanvas->Update();
+
+  TString json = TBufferJSON::ToJSON(fCanvas);
+  fCanvasHolder->SetTitle(TBase64::Encode(json).Data());
+  fCanvasHolder->StampObjProps();
+}
+
 void MainWindow::createProjectionStuff(REX::REveManager *eveMng)
 {
   // -------------------Tracker XY View ----------------------------------
@@ -762,6 +847,12 @@ void MainWindow::createProjectionStuff(REX::REveManager *eveMng)
   XYCaloDisk1View = eveMng->SpawnNewViewer("XYCaloDisk1 View", "");
   XYCaloDisk1View->AddScene(XYCaloDisk1GeomScene);
   XYCaloDisk1View->AddScene(XYCaloDisk1EventScene);
+
+  for (auto v: {TrackerXYView, XYCaloDisk0View, XYCaloDisk1View, rhoZView}){
+    v->SetAxesType(REX::REveViewer::kAxesOrigin);
+    v->StampObjProps();
+  }
+  createHistogramView();
 }
 
 
@@ -776,6 +867,10 @@ void MainWindow::showEvents(REX::REveManager *eveMng, REX::REveElement* &eventSc
   std::vector<const KalSeedPtrCollection*> track_list = std::get<1>(data.track_tuple);
   if(drawOpts.addTracks and track_list.size() !=0) {
     pass_data->FillKinKalTrajectory(eveMng, firstLoop, eventScene, data.track_tuple, KKOpts.addKalInter,  KKOpts.addTrkStrawHits, KKOpts.addTrkCaloHits, t1, t2);
+
+    auto const& track_list = std::get<1>(data.track_tuple);
+    const mu2e::KalSeedPtrCollection* seedcol = track_list[0]; 
+    redrawCanvas(seedcol);
   }
    if(drawOpts.addCrvTrack) {
      pass_data->AddCRVKalIntersection(eveMng, firstLoop, eventScene, data.track_tuple, KKOpts.addKalInter,  KKOpts.addTrkStrawHits, KKOpts.addTrkCaloHits, t1, t2, data.crvcoin_tuple, geomOpts.extracted, drawOpts.addCrvBars);

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -767,8 +767,6 @@ void MainWindow::createProjectionStuff(REX::REveManager *eveMng)
     v->SetAxesType(REX::REveViewer::kAxesOrigin);
     v->StampObjProps();
   }
-  fTrackerCalo2DViews = new TrackerCalo2DViews();
-  fTrackerCalo2DViews->createHistogramView();
 }
 
 
@@ -786,9 +784,12 @@ void MainWindow::showEvents(REX::REveManager *eveMng, REX::REveElement* &eventSc
 
     auto const& track_list = std::get<1>(data.track_tuple);
     const mu2e::KalSeedPtrCollection* seedcol = track_list[0];
-    if(drawOpts.addTrackerHist) fTrackerCalo2DViews->redrawCanvas(seedcol);
+    if(drawOpts.addTrackerHist) {
+      fTrackerCalo2DViews = new TrackerCalo2DViews();
+      fTrackerCalo2DViews->createHistogramView();
+      fTrackerCalo2DViews->redrawCanvas(seedcol);
+    }
     //redrawCanvas(seedcol);
-  }
   }
    if(drawOpts.addCrvTrack) {
      pass_data->AddCRVKalIntersection(eveMng, firstLoop, eventScene, data.track_tuple, KKOpts.addKalInter,  KKOpts.addTrkStrawHits, KKOpts.addTrkCaloHits, t1, t2, data.crvcoin_tuple, geomOpts.extracted, drawOpts.addCrvBars);

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -718,90 +718,17 @@ void MainWindow::projectEvents(REX::REveManager *eveMng)
   }
 }
 
-void MainWindow::createHistogramView(){
-  auto &evMng = *ROOT::Experimental::gEve;
-  auto histScene = evMng.SpawnNewScene("Histograms", "Histogram Scene");
-  fCanvasHolder = new ROOT::Experimental::REvePointSet("CanvasData");
-  histScene->AddElement(fCanvasHolder);
-  fCanvas = new TCanvas("Mu2eCanvas", "Mu2e stats", 800, 600);
-  auto canvasViewer = evMng.SpawnNewViewer("Histogram viewer", "Mu2e Histogram");
-  canvasViewer->AddScene(histScene);
+/*void MainWindow::createHistogramView(){
+  fTrackerCalo2DViews->createHistogramView();
 }
 
 void MainWindow::drawTrackerStation(const mu2e::KalSeedPtrCollection* seedcol){
-  if (!fCanvas || !fCanvasHolder) return;
-  fCanvas->cd();
-  fCanvas->Clear();
-  mu2e::GeomHandle<mu2e::Tracker> tracker;
-  int planeId = 22;
-  int panelId = 5;
-  const mu2e::Plane& plane = tracker->getPlane(planeId);
-  const mu2e::Panel& panel = plane.getPanel(panelId);
-  TPad* pad = new TPad("p_0_0", "First Panel", 0.05, 0.05, 0.95, 0.95);
-  pad->Draw();
-  pad->cd();
-  std::string frameTitle = "Plane" + std::to_string(planeId) + "Panel" + std::to_string(panelId) + "YZ view; Z [mm]; Y [mm]";
-  TH2F* frame = new TH2F("frame", frameTitle.c_str(), 100, -20, 20, 100, -200, 200);
-  frame->SetStats(0);
-  frame->Draw();
-  std::map<mu2e::StrawId, const mu2e::TrkStrawHitSeed*> hitDataMap;
-  if(seedcol != nullptr){
-    for (auto const& kseedptr : *seedcol){
-     const mu2e::KalSeed& kseed = *kseedptr; 
-      for (auto const& hit : kseed.hits()){
-        //hitStrawIds.insert(hit.strawId());
-        hitDataMap[hit.strawId()] = &hit;
-        std::cout<<"Hit straw ID = "<<hit.strawId()<<std::endl;
-      }
-    }
-  }
-  double strawRadius = tracker->strawProperties()._strawOuterRadius;
-  for (size_t iStraw=0; iStraw < panel.nStraws(); ++iStraw){
-    const mu2e::Straw& straw = panel.getStraw(iStraw);
-    CLHEP::Hep3Vector pos_l = panel.dsToPanel()*straw.getMidPoint();
-    std::cout<<"iStraw = "<<iStraw<<" pos_l x = "<<pos_l.x()<<" y = "<<pos_l.y()<<" z = "<<pos_l.z()<<" radius = "<<strawRadius<<" ID = "<<straw.id()<<std::endl;
-    TEllipse *circ = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
-    circ->SetLineColor(kGray+2);
-    circ->SetFillStyle(0);
-    circ->Draw();
-    //if(hitStrawIds.find(straw.id()) != hitStrawIds.end()){
-    if(hitDataMap.count(straw.id())){
-      const auto* hit = hitDataMap[straw.id()];
-      TEllipse *hitcirc = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
-      hitcirc->SetLineColor(kBlack);
-      hitcirc->SetFillStyle(0);
-      hitcirc->Draw();
-      double rdrift = hit->driftRadius();
-      TEllipse *rcirc = new TEllipse(pos_l.z(), pos_l.y(), rdrift, rdrift);
-      rcirc->SetLineColor(kRed);
-      rcirc->SetFillStyle(0);
-      rcirc->Draw();
-      double sz = pos_l.z();
-      double sy = pos_l.y();
-      TGraph *g = new TGraph(1, &sz, &sy);
-      g->SetMarkerColorAlpha(kWhite,0);
-      g->SetName(Form("Straw %d: %.2f MeV",straw.id().getStraw(), hit->energyDep()));
-      g->Draw("P SAME");
-    }
-  }
-  TLatex *tex = new TLatex();
-  tex->SetNDC();
-  tex->SetTextSize(0.04);
-  tex->DrawLatex(0.7, 0.92, Form("Plane %d : Panel %d", planeId, panelId));
-  pad->Modified();
-  pad->Update();
+  fTrackerCalo2DViews->drawTrackerStation(seedcol);
 }
 
 void MainWindow::redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol){
-  if (!fCanvas || !fCanvasHolder) return;
-  drawTrackerStation(seedcol);
-  fCanvas->Modified();
-  fCanvas->Update();
-
-  TString json = TBufferJSON::ToJSON(fCanvas);
-  fCanvasHolder->SetTitle(TBase64::Encode(json).Data());
-  fCanvasHolder->StampObjProps();
-}
+  fTrackerCalo2DViews->redrawCanvas(seedcol);
+}*/
 
 void MainWindow::createProjectionStuff(REX::REveManager *eveMng)
 {
@@ -852,7 +779,9 @@ void MainWindow::createProjectionStuff(REX::REveManager *eveMng)
     v->SetAxesType(REX::REveViewer::kAxesOrigin);
     v->StampObjProps();
   }
-  createHistogramView();
+  fTrackerCalo2DViews = new TrackerCalo2DViews();
+  fTrackerCalo2DViews->createHistogramView();
+  //createHistogramView();
 }
 
 
@@ -869,8 +798,9 @@ void MainWindow::showEvents(REX::REveManager *eveMng, REX::REveElement* &eventSc
     pass_data->FillKinKalTrajectory(eveMng, firstLoop, eventScene, data.track_tuple, KKOpts.addKalInter,  KKOpts.addTrkStrawHits, KKOpts.addTrkCaloHits, t1, t2);
 
     auto const& track_list = std::get<1>(data.track_tuple);
-    const mu2e::KalSeedPtrCollection* seedcol = track_list[0]; 
-    redrawCanvas(seedcol);
+    const mu2e::KalSeedPtrCollection* seedcol = track_list[0];
+    fTrackerCalo2DViews->redrawCanvas(seedcol);
+    //redrawCanvas(seedcol);
   }
    if(drawOpts.addCrvTrack) {
      pass_data->AddCRVKalIntersection(eveMng, firstLoop, eventScene, data.track_tuple, KKOpts.addKalInter,  KKOpts.addTrkStrawHits, KKOpts.addTrkCaloHits, t1, t2, data.crvcoin_tuple, geomOpts.extracted, drawOpts.addCrvBars);

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -786,7 +786,7 @@ void MainWindow::showEvents(REX::REveManager *eveMng, REX::REveElement* &eventSc
     const mu2e::KalSeedPtrCollection* seedcol = track_list[0];
     if(drawOpts.addTrackerHist) {
       fTrackerCalo2DViews = new TrackerCalo2DViews();
-      fTrackerCalo2DViews->createHistogramView();
+      //fTrackerCalo2DViews->createHistogramView();
       fTrackerCalo2DViews->redrawCanvas(seedcol);
     }
     //redrawCanvas(seedcol);

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -718,18 +718,6 @@ void MainWindow::projectEvents(REX::REveManager *eveMng)
   }
 }
 
-/*void MainWindow::createHistogramView(){
-  fTrackerCalo2DViews->createHistogramView();
-}
-
-void MainWindow::drawTrackerStation(const mu2e::KalSeedPtrCollection* seedcol){
-  fTrackerCalo2DViews->drawTrackerStation(seedcol);
-}
-
-void MainWindow::redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol){
-  fTrackerCalo2DViews->redrawCanvas(seedcol);
-}*/
-
 void MainWindow::createProjectionStuff(REX::REveManager *eveMng)
 {
   // -------------------Tracker XY View ----------------------------------
@@ -781,7 +769,6 @@ void MainWindow::createProjectionStuff(REX::REveManager *eveMng)
   }
   fTrackerCalo2DViews = new TrackerCalo2DViews();
   fTrackerCalo2DViews->createHistogramView();
-  //createHistogramView();
 }
 
 

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -786,8 +786,9 @@ void MainWindow::showEvents(REX::REveManager *eveMng, REX::REveElement* &eventSc
 
     auto const& track_list = std::get<1>(data.track_tuple);
     const mu2e::KalSeedPtrCollection* seedcol = track_list[0];
-    fTrackerCalo2DViews->redrawCanvas(seedcol);
+    if(drawOpts.addTrackerHist) fTrackerCalo2DViews->redrawCanvas(seedcol);
     //redrawCanvas(seedcol);
+  }
   }
    if(drawOpts.addCrvTrack) {
      pass_data->AddCRVKalIntersection(eveMng, firstLoop, eventScene, data.track_tuple, KKOpts.addKalInter,  KKOpts.addTrkStrawHits, KKOpts.addTrkCaloHits, t1, t2, data.crvcoin_tuple, geomOpts.extracted, drawOpts.addCrvBars);

--- a/src/Mu2eEventDisplay_module.cc
+++ b/src/Mu2eEventDisplay_module.cc
@@ -290,6 +290,7 @@ namespace mu2e
     <<" addClusters : "<<filler_.addClusters_
     <<" addHelices : "<<filler_.addHelixSeeds_
     <<" addTracks : "<<filler_.addKalSeeds_
+    <<" addTrackerHist : "<<filler_.addTrackerHist_
     <<" addCosmicTrackSeeds : "<<filler_.addCosmicTrackSeeds_ << std::endl;
   }
 
@@ -690,7 +691,7 @@ void Mu2eEventDisplay::FillAnyCollection(const art::Event& evt, std::vector<std:
       if(diagLevel_ == 1) std::cout<<"[Mu2eEventDisplay : process_single_event] -- calls to data interface "<<std::endl;
 
       // Create a structure defining which data products should be drawn (based on module configuration).
-       DrawOptions drawOpts(filler_.addCosmicTrackSeeds_, filler_.addHelixSeeds_, filler_.addKalSeeds_, filler_.addCaloDigis_, filler_.addClusters_, filler_.addHits_, filler_.addBkgClusters_, filler_.addCrvRecoPulse_, filler_.addCrvClusters_, filler_.addCrvTrack_, filler_.addTimeClusters_, filler_.addTrkHits_, filler_.addMCTraj_, filler_.addSurfSteps_, filler_.addSimParts_, addErrBar_, addCrystalHits_, addCrvBars_);
+        DrawOptions drawOpts(filler_.addCosmicTrackSeeds_, filler_.addHelixSeeds_, filler_.addKalSeeds_, filler_.addCaloDigis_, filler_.addClusters_, filler_.addHits_, filler_.addBkgClusters_, filler_.addCrvRecoPulse_, filler_.addCrvClusters_, filler_.addCrvTrack_, filler_.addTimeClusters_, filler_.addTrkHits_, filler_.addMCTraj_, filler_.addSurfSteps_, filler_.addSimParts_, filler_.addTrackerHist_, addErrBar_, addCrystalHits_, addCrvBars_);
 
       // Create a structure defining visualization options specific to Kinematic/Kalman fitting results.
       KinKalOptions KKOpts(addKalInter_, addTrkStrawHits_, addTrkCaloHits_);

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -34,7 +34,8 @@ void TrackerCalo2DViews::drawTrackerStation(const mu2e::KalSeedPtrCollection* se
     if (!fCanvas || !fCanvasHolder) return;
     fCanvas->cd();
     fCanvas->Clear();
-    
+
+    fCanvas->Divide(2, 3, 0.005, 0.005);
     mu2e::GeomHandle<mu2e::Tracker> tracker;
     int planeId = 22;
     
@@ -51,25 +52,17 @@ void TrackerCalo2DViews::drawTrackerStation(const mu2e::KalSeedPtrCollection* se
     const mu2e::Plane& plane = tracker->getPlane(planeId);
     double strawRadius = tracker->strawProperties()._strawOuterRadius;
 
-    for (int panelId = 0; panelId < 12; ++panelId) {
+    for (int panelId = 0; panelId < 6; ++panelId) {
         const mu2e::Panel& panel = plane.getPanel(panelId);
-        
-        int row = panelId / 4;
-        int col = panelId % 4;
-        double x1 = col * 0.25;
-        double x2 = (col + 1) * 0.25;
-        double y1 = (2 - row) * 0.333;
-        double y2 = (3 - row) * 0.333;
-        
-        TPad* pad = new TPad(Form("p_%d_%d", row, col), Form("Panel %d", panelId), x1, y1, x2, y2);
-        pad->Draw();
-        pad->cd();
-        
-        std::string frameTitle = "Plane" + std::to_string(planeId) + "Panel" + std::to_string(panelId) + "YZ view; Z [mm]; Y [mm]";
-        TH2F* frame = new TH2F("frame", frameTitle.c_str(), 100, -20, 20, 100, -200, 200);
+        std::cout<<"Plane ID = "<<planeId<<" panel = "<<panelId<<std::endl;
+        fCanvas->cd(panelId+1);
+        gPad->SetBottomMargin(0.15);
+        gPad->SetLeftMargin(0.15);
+        std::string frameTitle = "Plane " + std::to_string(planeId) + " Panel " + std::to_string(panelId);
+        TH2F* frame = new TH2F(Form("h_%d", panelId), frameTitle.c_str(), 100, -20, 20, 100, -200, 200);
         frame->SetStats(0);
         frame->Draw();
-        
+        std::cout<<"nstraws = "<<panel.nStraws()<<std::endl;
         for (size_t iStraw=0; iStraw < panel.nStraws(); ++iStraw){
             const mu2e::Straw& straw = panel.getStraw(iStraw);
             CLHEP::Hep3Vector pos_l = panel.dsToPanel()*straw.getMidPoint();
@@ -103,10 +96,8 @@ void TrackerCalo2DViews::drawTrackerStation(const mu2e::KalSeedPtrCollection* se
         
         TLatex *tex = new TLatex();
         tex->SetNDC();
-        tex->SetTextSize(0.03);
-        tex->DrawLatex(0.6, 0.9, Form("Plane %d : Panel %d", planeId, panelId));
-        pad->Modified();
-        pad->Update();
+        tex->SetTextSize(0.05);
+        tex->DrawLatex(0.25, 0.85, Form("Panel %d", panelId));
     }
 }
 

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -9,6 +9,7 @@
 #include <TBase64.h>
 #include <iostream>
 #include <map>
+#include "Offline/Mu2eKinKal/inc/WireHitState.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include "Offline/TrackerGeom/inc/Plane.hh"
@@ -82,7 +83,14 @@ void TrackerCalo2DViews::drawTrackerStation(const mu2e::KalSeedPtrCollection* se
                 double rdrift = hit->driftRadius();
                 TEllipse *rcirc = new TEllipse(pos_l.z(), pos_l.y(), rdrift, rdrift);
                 rcirc->SetLineColor(kRed);
-                rcirc->SetFillStyle(0);
+                
+                mu2e::WireHitState whs(mu2e::WireHitState::State(hit->strawHitState()), mu2e::StrawHitUpdaters::algorithm(hit->strawHitAlgo()), hit->strawHitKkshFlag());
+                if (whs.active() && whs.driftConstraint()) {
+                    rcirc->SetFillColor(kLightCyan);
+                    rcirc->SetFillStyle(1);
+                } else {
+                    rcirc->SetFillStyle(0);
+                }
                 rcirc->Draw();
                 
                 double sz = pos_l.z();

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -50,11 +50,16 @@ void TrackerCalo2DViews::drawTrackerStation(const mu2e::KalSeedPtrCollection* se
     }
 
     double strawRadius = tracker->strawProperties()._strawOuterRadius;
-    std::array<int, 6> padMap = {5, 4, 1, 2, 3, 6};
+
+    std::vector<int> planeIdA = {0,3,4,7,8,11,12,15,16,19,20,23,24,27,28,31,32,35};
 
     for (const auto& planeId : uniquePlanes) {
         std::cout << "Processing Canvas for Plane " << planeId << std::endl;
-        
+        std::array<int, 6> padMap;
+        if(std::find(planeIdA.begin(), planeIdA.end(), planeId) != planeIdA.end())
+          padMap = {2, 3, 6, 5, 4, 1};
+        else
+          padMap = {5, 4, 1, 2, 3, 6};
         // Fix: Proper TCanvas name and title string formatting
         TString canvasName = Form("Canvas_Plane_%d", planeId);
         TString canvasTitle = Form("Mu2e Tracker Plane %d - Y vs Z View", planeId);

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -37,18 +37,6 @@ void TrackerCalo2DViews::drawTrackerStation(const mu2e::KalSeedPtrCollection* se
     
     mu2e::GeomHandle<mu2e::Tracker> tracker;
     int planeId = 22;
-    int panelId = 5;
-    const mu2e::Plane& plane = tracker->getPlane(planeId);
-    const mu2e::Panel& panel = plane.getPanel(panelId);
-    
-    TPad* pad = new TPad("p_0_0", "First Panel", 0.05, 0.05, 0.95, 0.95);
-    pad->Draw();
-    pad->cd();
-    
-    std::string frameTitle = "Plane" + std::to_string(planeId) + "Panel" + std::to_string(panelId) + "YZ view; Z [mm]; Y [mm]";
-    TH2F* frame = new TH2F("frame", frameTitle.c_str(), 100, -20, 20, 100, -200, 200);
-    frame->SetStats(0);
-    frame->Draw();
     
     std::map<mu2e::StrawId, const mu2e::TrkStrawHitSeed*> hitDataMap;
     if(seedcol != nullptr){
@@ -56,51 +44,70 @@ void TrackerCalo2DViews::drawTrackerStation(const mu2e::KalSeedPtrCollection* se
             const mu2e::KalSeed& kseed = *kseedptr; 
             for (auto const& hit : kseed.hits()){
                 hitDataMap[hit.strawId()] = &hit;
-                std::cout << "Hit straw ID = " << hit.strawId() << std::endl;
             }
         }
     }
     
+    const mu2e::Plane& plane = tracker->getPlane(planeId);
     double strawRadius = tracker->strawProperties()._strawOuterRadius;
-    for (size_t iStraw=0; iStraw < panel.nStraws(); ++iStraw){
-        const mu2e::Straw& straw = panel.getStraw(iStraw);
-        CLHEP::Hep3Vector pos_l = panel.dsToPanel()*straw.getMidPoint();
+
+    for (int panelId = 0; panelId < 12; ++panelId) {
+        const mu2e::Panel& panel = plane.getPanel(panelId);
         
-        std::cout << "iStraw = " << iStraw << " pos_l x = " << pos_l.x() << " y = " << pos_l.y() << " z = " << pos_l.z() << " radius = " << strawRadius << " ID = " << straw.id() << std::endl;
+        int row = panelId / 4;
+        int col = panelId % 4;
+        double x1 = col * 0.25;
+        double x2 = (col + 1) * 0.25;
+        double y1 = (2 - row) * 0.333;
+        double y2 = (3 - row) * 0.333;
         
-        TEllipse *circ = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
-        circ->SetLineColor(kGray+2);
-        circ->SetFillStyle(0);
-        circ->Draw();
+        TPad* pad = new TPad(Form("p_%d_%d", row, col), Form("Panel %d", panelId), x1, y1, x2, y2);
+        pad->Draw();
+        pad->cd();
         
-        if(hitDataMap.count(straw.id())){
-            const auto* hit = hitDataMap[straw.id()];
-            TEllipse *hitcirc = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
-            hitcirc->SetLineColor(kBlack);
-            hitcirc->SetFillStyle(0);
-            hitcirc->Draw();
+        std::string frameTitle = "Plane" + std::to_string(planeId) + "Panel" + std::to_string(panelId) + "YZ view; Z [mm]; Y [mm]";
+        TH2F* frame = new TH2F("frame", frameTitle.c_str(), 100, -20, 20, 100, -200, 200);
+        frame->SetStats(0);
+        frame->Draw();
+        
+        for (size_t iStraw=0; iStraw < panel.nStraws(); ++iStraw){
+            const mu2e::Straw& straw = panel.getStraw(iStraw);
+            CLHEP::Hep3Vector pos_l = panel.dsToPanel()*straw.getMidPoint();
             
-            double rdrift = hit->driftRadius();
-            TEllipse *rcirc = new TEllipse(pos_l.z(), pos_l.y(), rdrift, rdrift);
-            rcirc->SetLineColor(kRed);
-            rcirc->SetFillStyle(0);
-            rcirc->Draw();
+            TEllipse *circ = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
+            circ->SetLineColor(kGray+2);
+            circ->SetFillStyle(0);
+            circ->Draw();
             
-            double sz = pos_l.z();
-            double sy = pos_l.y();
-            TGraph *g = new TGraph(1, &sz, &sy);
-            g->SetMarkerColorAlpha(kWhite,0);
-            g->SetName(Form("Straw %d: %.2f MeV",straw.id().getStraw(), hit->energyDep()));
-            g->Draw("P SAME");
+            if(hitDataMap.count(straw.id())){
+                const auto* hit = hitDataMap[straw.id()];
+                TEllipse *hitcirc = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
+                hitcirc->SetLineColor(kBlack);
+                hitcirc->SetFillStyle(0);
+                hitcirc->Draw();
+                
+                double rdrift = hit->driftRadius();
+                TEllipse *rcirc = new TEllipse(pos_l.z(), pos_l.y(), rdrift, rdrift);
+                rcirc->SetLineColor(kRed);
+                rcirc->SetFillStyle(0);
+                rcirc->Draw();
+                
+                double sz = pos_l.z();
+                double sy = pos_l.y();
+                TGraph *g = new TGraph(1, &sz, &sy);
+                g->SetMarkerColorAlpha(kWhite,0);
+                g->SetName(Form("Straw %d: %.2f MeV",straw.id().getStraw(), hit->energyDep()));
+                g->Draw("P SAME");
+            }
         }
+        
+        TLatex *tex = new TLatex();
+        tex->SetNDC();
+        tex->SetTextSize(0.03);
+        tex->DrawLatex(0.6, 0.9, Form("Plane %d : Panel %d", planeId, panelId));
+        pad->Modified();
+        pad->Update();
     }
-    
-    TLatex *tex = new TLatex();
-    tex->SetNDC();
-    tex->SetTextSize(0.04);
-    tex->DrawLatex(0.7, 0.92, Form("Plane %d : Panel %d", planeId, panelId));
-    pad->Modified();
-    pad->Update();
 }
 
 void TrackerCalo2DViews::redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol) {

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -9,6 +9,7 @@
 #include <TBase64.h>
 #include <iostream>
 #include <map>
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include "Offline/TrackerGeom/inc/Plane.hh"
 #include "Offline/TrackerGeom/inc/Panel.hh"

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -25,7 +25,7 @@ void TrackerCalo2DViews::createHistogramView() {
     auto histScene = evMng.SpawnNewScene("Histograms", "Histogram Scene");
     fCanvasHolder = new REX::REvePointSet("CanvasData");
     histScene->AddElement(fCanvasHolder);
-    fCanvas = new TCanvas("Mu2eCanvas", "Mu2e stats", 800, 600);
+    fCanvas = new TCanvas("Mu2eCanvas", "Tracker Plane Y v/s Z View", 800, 600);
     auto canvasViewer = evMng.SpawnNewViewer("Histogram viewer", "Mu2e Histogram");
     canvasViewer->AddScene(histScene);
 }
@@ -93,11 +93,6 @@ void TrackerCalo2DViews::drawTrackerStation(const mu2e::KalSeedPtrCollection* se
                 g->Draw("P SAME");
             }
         }
-        
-        TLatex *tex = new TLatex();
-        tex->SetNDC();
-        tex->SetTextSize(0.05);
-        tex->DrawLatex(0.25, 0.85, Form("Panel %d", panelId));
     }
 }
 

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -1,0 +1,116 @@
+#include "EventDisplay/inc/TrackerCalo2DViews.hh"
+#include <TPad.h>
+#include <TH2F.h>
+#include <TEllipse.h>
+#include <TLine.h>
+#include <TLatex.h>
+#include <TGraph.h>
+#include <TBufferJSON.h>
+#include <TBase64.h>
+#include <iostream>
+#include <map>
+#include "Offline/TrackerGeom/inc/Tracker.hh"
+#include "Offline/TrackerGeom/inc/Plane.hh"
+#include "Offline/TrackerGeom/inc/Panel.hh"
+#include "Offline/TrackerGeom/inc/Straw.hh"
+
+namespace mu2e {
+
+TrackerCalo2DViews::TrackerCalo2DViews() {}
+TrackerCalo2DViews::~TrackerCalo2DViews() {}
+
+void TrackerCalo2DViews::createHistogramView() {
+    auto &evMng = *REX::gEve;
+    auto histScene = evMng.SpawnNewScene("Histograms", "Histogram Scene");
+    fCanvasHolder = new REX::REvePointSet("CanvasData");
+    histScene->AddElement(fCanvasHolder);
+    fCanvas = new TCanvas("Mu2eCanvas", "Mu2e stats", 800, 600);
+    auto canvasViewer = evMng.SpawnNewViewer("Histogram viewer", "Mu2e Histogram");
+    canvasViewer->AddScene(histScene);
+}
+
+void TrackerCalo2DViews::drawTrackerStation(const mu2e::KalSeedPtrCollection* seedcol) {
+    if (!fCanvas || !fCanvasHolder) return;
+    fCanvas->cd();
+    fCanvas->Clear();
+    
+    mu2e::GeomHandle<mu2e::Tracker> tracker;
+    int planeId = 22;
+    int panelId = 5;
+    const mu2e::Plane& plane = tracker->getPlane(planeId);
+    const mu2e::Panel& panel = plane.getPanel(panelId);
+    
+    TPad* pad = new TPad("p_0_0", "First Panel", 0.05, 0.05, 0.95, 0.95);
+    pad->Draw();
+    pad->cd();
+    
+    std::string frameTitle = "Plane" + std::to_string(planeId) + "Panel" + std::to_string(panelId) + "YZ view; Z [mm]; Y [mm]";
+    TH2F* frame = new TH2F("frame", frameTitle.c_str(), 100, -20, 20, 100, -200, 200);
+    frame->SetStats(0);
+    frame->Draw();
+    
+    std::map<mu2e::StrawId, const mu2e::TrkStrawHitSeed*> hitDataMap;
+    if(seedcol != nullptr){
+        for (auto const& kseedptr : *seedcol){
+            const mu2e::KalSeed& kseed = *kseedptr; 
+            for (auto const& hit : kseed.hits()){
+                hitDataMap[hit.strawId()] = &hit;
+                std::cout << "Hit straw ID = " << hit.strawId() << std::endl;
+            }
+        }
+    }
+    
+    double strawRadius = tracker->strawProperties()._strawOuterRadius;
+    for (size_t iStraw=0; iStraw < panel.nStraws(); ++iStraw){
+        const mu2e::Straw& straw = panel.getStraw(iStraw);
+        CLHEP::Hep3Vector pos_l = panel.dsToPanel()*straw.getMidPoint();
+        
+        std::cout << "iStraw = " << iStraw << " pos_l x = " << pos_l.x() << " y = " << pos_l.y() << " z = " << pos_l.z() << " radius = " << strawRadius << " ID = " << straw.id() << std::endl;
+        
+        TEllipse *circ = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
+        circ->SetLineColor(kGray+2);
+        circ->SetFillStyle(0);
+        circ->Draw();
+        
+        if(hitDataMap.count(straw.id())){
+            const auto* hit = hitDataMap[straw.id()];
+            TEllipse *hitcirc = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
+            hitcirc->SetLineColor(kBlack);
+            hitcirc->SetFillStyle(0);
+            hitcirc->Draw();
+            
+            double rdrift = hit->driftRadius();
+            TEllipse *rcirc = new TEllipse(pos_l.z(), pos_l.y(), rdrift, rdrift);
+            rcirc->SetLineColor(kRed);
+            rcirc->SetFillStyle(0);
+            rcirc->Draw();
+            
+            double sz = pos_l.z();
+            double sy = pos_l.y();
+            TGraph *g = new TGraph(1, &sz, &sy);
+            g->SetMarkerColorAlpha(kWhite,0);
+            g->SetName(Form("Straw %d: %.2f MeV",straw.id().getStraw(), hit->energyDep()));
+            g->Draw("P SAME");
+        }
+    }
+    
+    TLatex *tex = new TLatex();
+    tex->SetNDC();
+    tex->SetTextSize(0.04);
+    tex->DrawLatex(0.7, 0.92, Form("Plane %d : Panel %d", planeId, panelId));
+    pad->Modified();
+    pad->Update();
+}
+
+void TrackerCalo2DViews::redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol) {
+    if (!fCanvas || !fCanvasHolder) return;
+    drawTrackerStation(seedcol);
+    fCanvas->Modified();
+    fCanvas->Update();
+    
+    TString json = TBufferJSON::ToJSON(fCanvas);
+    fCanvasHolder->SetTitle(TBase64::Encode(json).Data());
+    fCanvasHolder->StampObjProps();
+}
+
+} // namespace mu2e

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -32,87 +32,127 @@ void TrackerCalo2DViews::createHistogramView() {
 }
 
 void TrackerCalo2DViews::drawTrackerStation(const mu2e::KalSeedPtrCollection* seedcol) {
-    if (!fCanvas || !fCanvasHolder) return;
-    fCanvas->cd();
-    fCanvas->Clear();
-
-    fCanvas->Divide(2, 3, 0.005, 0.005);
+    // Note: We can draw without fCanvas/fCanvasHolder since you want offline viewing
     mu2e::GeomHandle<mu2e::Tracker> tracker;
-    int planeId = 22;
     
     std::map<mu2e::StrawId, const mu2e::TrkStrawHitSeed*> hitDataMap;
-    if(seedcol != nullptr){
-        for (auto const& kseedptr : *seedcol){
+    std::set<int> uniquePlanes;
+
+    if (seedcol != nullptr) {
+        for (auto const& kseedptr : *seedcol) {
             const mu2e::KalSeed& kseed = *kseedptr; 
-            for (auto const& hit : kseed.hits()){
-                hitDataMap[hit.strawId()] = &hit;
+            for (auto const& hit : kseed.hits()) {
+                mu2e::StrawId sid = hit.strawId();
+                uniquePlanes.insert(sid.getPlane());
+                hitDataMap[sid] = &hit;
             }
         }
     }
-    
-    const mu2e::Plane& plane = tracker->getPlane(planeId);
-    double strawRadius = tracker->strawProperties()._strawOuterRadius;
 
-    for (int panelId = 0; panelId < 6; ++panelId) {
-        const mu2e::Panel& panel = plane.getPanel(panelId);
-        std::cout<<"Plane ID = "<<planeId<<" panel = "<<panelId<<std::endl;
-        fCanvas->cd(panelId+1);
-        gPad->SetBottomMargin(0.15);
-        gPad->SetLeftMargin(0.15);
-        std::string frameTitle = "Plane " + std::to_string(planeId) + " Panel " + std::to_string(panelId);
-        TH2F* frame = new TH2F(Form("h_%d", panelId), frameTitle.c_str(), 100, -20, 20, 100, -200, 200);
-        frame->SetStats(0);
-        frame->Draw();
-        std::cout<<"nstraws = "<<panel.nStraws()<<std::endl;
-        for (size_t iStraw=0; iStraw < panel.nStraws(); ++iStraw){
-            const mu2e::Straw& straw = panel.getStraw(iStraw);
-            CLHEP::Hep3Vector pos_l = panel.dsToPanel()*straw.getMidPoint();
+    double strawRadius = tracker->strawProperties()._strawOuterRadius;
+    std::array<int, 6> padMap = {5, 4, 1, 2, 3, 6};
+
+    for (const auto& planeId : uniquePlanes) {
+        std::cout << "Processing Canvas for Plane " << planeId << std::endl;
+        
+        // Fix: Proper TCanvas name and title string formatting
+        TString canvasName = Form("Canvas_Plane_%d", planeId);
+        TString canvasTitle = Form("Mu2e Tracker Plane %d - Y vs Z View", planeId);
+        
+        TCanvas* planeCanvas = new TCanvas(canvasName, canvasTitle, 1000, 800);
+        planeCanvas->Divide(2, 3, 0.005, 0.005);
+
+        const mu2e::Plane& plane = tracker->getPlane(planeId);
+
+        for (int panelId = 0; panelId < 6; ++panelId) {
+            const mu2e::Panel& panel = plane.getPanel(panelId);
             
-            TEllipse *circ = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
-            circ->SetLineColor(kGray+2);
-            circ->SetFillStyle(0);
-            circ->Draw();
+            // 1. Calculate Bounds for this specific panel
+            double ymin = 1e9, ymax = -1e9, zmin = 1e9, zmax = -1e9;
+            for (size_t iStraw = 0; iStraw < panel.nStraws(); ++iStraw) {
+                const mu2e::Straw& straw = panel.getStraw(iStraw);
+                CLHEP::Hep3Vector pos_l = straw.getMidPoint();
+                ymin = std::min(ymin, pos_l.y());
+                ymax = std::max(ymax, pos_l.y());
+                zmin = std::min(zmin, pos_l.z());
+                zmax = std::max(zmax, pos_l.z());
+            }
+
+            // 2. Prepare the Pad
+            planeCanvas->cd(padMap[panelId]);
+            gPad->SetBottomMargin(0.15);
+            gPad->SetLeftMargin(0.15);
+
+            TString frameName = Form("h_plane%d_panel%d", planeId, panelId);
+            TString frameTitle = Form("Plane %d: Panel %d;Z (mm);Y (mm)", planeId, panelId);
             
-            if(hitDataMap.count(straw.id())){
-                const auto* hit = hitDataMap[straw.id()];
-                TEllipse *hitcirc = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
-                hitcirc->SetLineColor(kBlack);
-                hitcirc->SetFillStyle(0);
-                hitcirc->Draw();
+            TH2F* frame = new TH2F(frameName, frameTitle, 100, zmin - 20, zmax + 20, 100, ymin - 10, ymax + 10);
+            frame->SetStats(0);
+            frame->Draw();
+
+            // 3. Draw Straws and Hits
+            for (size_t iStraw = 0; iStraw < panel.nStraws(); ++iStraw) {
+                const mu2e::Straw& straw = panel.getStraw(iStraw);
+                CLHEP::Hep3Vector pos_l = straw.getMidPoint();
                 
-                double rdrift = hit->driftRadius();
-                TEllipse *rcirc = new TEllipse(pos_l.z(), pos_l.y(), rdrift, rdrift);
-                rcirc->SetLineColor(kRed);
+                // Base Straw Geometry
+                TEllipse *circ = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
+                circ->SetLineColor(kGray + 1);
+                circ->SetFillStyle(0);
+                circ->Draw();
                 
-                mu2e::WireHitState whs(mu2e::WireHitState::State(hit->strawHitState()), mu2e::StrawHitUpdaters::algorithm(hit->strawHitAlgo()), hit->strawHitKkshFlag());
-                if (whs.active() && whs.driftConstraint()) {
-                    rcirc->SetFillColor(kLightCyan);
-                    rcirc->SetFillStyle(1);
-                } else {
-                    rcirc->SetFillStyle(0);
+                // Check for Hits
+                if (hitDataMap.count(straw.id())) {
+                    const auto* hit = hitDataMap[straw.id()];
+                    
+                    // Hit Outline
+                    TEllipse *hitcirc = new TEllipse(pos_l.z(), pos_l.y(), strawRadius, strawRadius);
+                    hitcirc->SetLineColor(kBlack);
+                    hitcirc->SetLineWidth(2);
+                    hitcirc->SetFillStyle(0);
+                    hitcirc->Draw();
+                    
+                    // Drift Circle
+                    double rdrift = hit->driftRadius();
+                    TEllipse *rcirc = new TEllipse(pos_l.z(), pos_l.y(), rdrift, rdrift);
+                    
+                    mu2e::WireHitState whs = hit->wireHitState();
+                    if (whs.active() && whs.driftConstraint()) {
+                        rcirc->SetFillColor(kAzure - 9);
+                        rcirc->SetFillStyle(1001);
+                        rcirc->SetLineColor(kBlue);
+                    } else {
+                        rcirc->SetFillStyle(0);
+                        rcirc->SetLineColor(kRed);
+                        rcirc->SetLineStyle(2); // Dashed for inactive/unconstrained
+                    }
+                    rcirc->Draw();
+
+                    // Tooltip/Data Graph
+                    double sz = pos_l.z();
+                    double sy = pos_l.y();
+                    TGraph *g = new TGraph(1, &sz, &sy);
+                    g->SetMarkerStyle(1);
+                    g->SetMarkerColorAlpha(kWhite, 0);
+                    g->SetName(Form("Straw %d: %.2f MeV", straw.id().getStraw(), hit->energyDep()));
+                    g->Draw("P SAME");
                 }
-                rcirc->Draw();
-                
-                double sz = pos_l.z();
-                double sy = pos_l.y();
-                TGraph *g = new TGraph(1, &sz, &sy);
-                g->SetMarkerColorAlpha(kWhite,0);
-                g->SetName(Form("Straw %d: %.2f MeV",straw.id().getStraw(), hit->energyDep()));
-                g->Draw("P SAME");
             }
         }
+        // Update the canvas for offline viewing
+        planeCanvas->Update();
+        // Optional: planeCanvas->SaveAs(Form("Plane_%d.png", planeId));
     }
 }
-
+  
 void TrackerCalo2DViews::redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol) {
-    if (!fCanvas || !fCanvasHolder) return;
+  //if (!fCanvas || !fCanvasHolder) return;
     drawTrackerStation(seedcol);
-    fCanvas->Modified();
+    /* fCanvas->Modified();
     fCanvas->Update();
-    
     TString json = TBufferJSON::ToJSON(fCanvas);
     fCanvasHolder->SetTitle(TBase64::Encode(json).Data());
-    fCanvasHolder->StampObjProps();
+    fCanvasHolder->StampObjProps();*/
 }
 
 } // namespace mu2e


### PR DESCRIPTION
Created a fcl parameter AddTrackerHist that one can set to true to view the Y v/s Z views of the hit straws. 

-> 1 TCanvas per plane
-> Hits whose drift info was used in the track reconstruction are highlighted in blue
-> Right click on the hit to get its straw ID

<img width="2124" height="834" alt="Screenshot 2026-05-07 at 14 05 07" src="https://github.com/user-attachments/assets/14369c71-4f1b-46c0-9de0-2da0e41a1021" />
