### PR TITLE
Added calorimeter disks 2-D canvases

### DIFF
--- a/inc/TrackerCalo2DViews.hh
+++ b/inc/TrackerCalo2DViews.hh
@@ -8,6 +8,7 @@
 #include <ROOT/REveManager.hxx>
 #include <ROOT/REveScene.hxx>
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
+#include "Offline/RecoDataProducts/inc/CaloCluster.hh"
 #include <map>
 
 namespace REX = ROOT::Experimental;
@@ -22,7 +23,7 @@ public:
     void createHistogramView();
   void drawTrackerStation(const mu2e::KalSeedPtrCollection* seedcol); //, const CaloDigiCollection* calodigicol);
   void drawTrackerXYView(const mu2e::KalSeedPtrCollection* seedcol);
-  void drawCalorimeterDisk();
+  void drawCalorimeterDisk(const CaloClusterCollection* clustercol = nullptr);
   //void redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol);
 
 private:

--- a/inc/TrackerCalo2DViews.hh
+++ b/inc/TrackerCalo2DViews.hh
@@ -30,6 +30,7 @@ private:
     REX::REvePointSet* fCanvasHolder{nullptr};
     TCanvas* fCanvas{nullptr};
     TCanvas* fCaloCanvas{nullptr};
+    TCanvas* fCaloCanvas1{nullptr};
     TCanvas* fXYCanvas{nullptr};
     std::map<int, TCanvas*> fPlaneCanvases;
 };

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -823,11 +823,15 @@ void MainWindow::showEvents(REX::REveManager *eveMng, REX::REveElement* &eventSc
       pass_data->AddCaloDigis(eveMng, firstLoop, data.calodigi_tuple, eventScene);
     }
   }
-
   if(drawOpts.addClusters){
     std::vector<const CaloClusterCollection*> calocluster_list = std::get<1>(data.calocluster_tuple);
     if(calocluster_list.size() !=0 ) 
       pass_data->AddCaloClusters(eveMng, firstLoopCalo, data.calocluster_tuple, eventScene, drawOpts.addCrystalDraw);
+    if(drawOpts.addCaloHist and calocluster_list.size() !=0) {
+      fTrackerCalo2DViews = new TrackerCalo2DViews();
+      const CaloClusterCollection* clustercol = calocluster_list[0];
+      fTrackerCalo2DViews->drawCalorimeterDisk(clustercol);
+   }
   }
 
   std::vector<const HelixSeedCollection*> helix_list = std::get<1>(data.helix_tuple);

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -407,10 +407,7 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         for (const auto& cluster : *clustercol) {
             if (cluster.diskID() != 0) continue;
             CLHEP::Hep3Vector cog = cluster.cog3Vector();
-            std::cout<<"COG = "<<cog.x()<<"  "<<cog.y()<<std::endl; 
-            //CLHEP::Hep3Vector localPos = calo->geomUtil().mu2eToDisk(0, cog);
             energyHist->Fill(cog.x(), cog.y(), cluster.energyDep());
-            //std::cout<<"Calo Cluster Crystal position = "<<localPos.x()<<"  "<<localPos.y()<<" energy dep = "<<cluster.energyDep()<<std::endl;
         }
     }
 
@@ -466,14 +463,13 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     energyHist1->SetDirectory(0);
     energyHist1->SetStats(0);
     gStyle->SetPalette(kBird);
-    energyHist1->GetZaxis()->SetTitle("Energy Deposition (MeV)");
+    energyHist1->GetZaxis()->SetTitle("edep (MeV)");
 
     if (clustercol != nullptr) {
         for (const auto& cluster : *clustercol) {
             if (cluster.diskID() != 1) continue;
             CLHEP::Hep3Vector cog = cluster.cog3Vector();
-            CLHEP::Hep3Vector localPos = calo->geomUtil().mu2eToDisk(1, cog);
-            energyHist1->Fill(localPos.x(), localPos.y(), cluster.energyDep());
+            energyHist1->Fill(cog.x(), cog.y(), cluster.energyDep());
         }
     }
 

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -407,9 +407,7 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     double crystalSizeY = disk.crystal(0).size().y();
     int nbinsX = std::max(1, (int)std::round((xmax - xmin) / crystalSizeX));
     int nbinsY = std::max(1, (int)std::round((ymax - ymin) / crystalSizeY));
-    TH2F* energyHist = new TH2F("calo_disk_energy",
-                                 "Calorimeter Disk 0 - Hit Energy Deposition;X (mm);Y (mm)",
-                                 nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+    TH2F* energyHist = new TH2F("calo_disk_energy", "Calorimeter Disk 0;X (mm);Y (mm)", nbinsX, xmin, xmax, nbinsY, ymin, ymax);
     energyHist->SetDirectory(0);
     energyHist->SetStats(0);
     gStyle->SetPalette(kBird);
@@ -441,8 +439,7 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         g->SetMarkerStyle(20);
         g->SetMarkerSize(0.5);
         g->SetMarkerColorAlpha(kWhite, 0);
-        g->SetName(Form("calo_hit_%d", h.crystalID));
-        g->SetTitle(Form("CrystalID %d  time=%.2f ns  eDep=%.3f MeV", h.crystalID, h.time, h.eDep));
+        g->SetName(Form("Crystal %d  time=%.2f ns  eDep=%.2f MeV", h.crystalID, h.time, h.eDep));
         g->Draw("P SAME");
     }
 

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -1,6 +1,7 @@
 #include "EventDisplay/inc/TrackerCalo2DViews.hh"
 #include <TPad.h>
 #include <TH2F.h>
+#include <TH2Poly.h>
 #include <TBox.h>
 #include <TEllipse.h>
 #include <TLine.h>
@@ -367,7 +368,7 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     mu2e::GeomHandle<mu2e::DiskCalorimeter> calo;
 
     // Collect per-hit data from cluster hit vectors
-    struct HitInfo { int crystalID; float time; float eDep; double cx; double cy; int diskID; };
+    struct HitInfo { int crystalID; float time; float eDep; double cx; double cy; double dx; double dy; int diskID; };
     std::vector<HitInfo> allHits;
     if (clustercol != nullptr) {
         for (const auto& cluster : *clustercol) {
@@ -375,7 +376,9 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
                 const mu2e::CaloHit& hit = *hitPtr;
                 const mu2e::Crystal& cr  = calo->crystal(hit.crystalID());
                 allHits.push_back({hit.crystalID(), hit.time(), hit.energyDep(),
-                                   cr.localPosition().x(), cr.localPosition().y(), cr.diskID()});
+                                   cr.localPosition().x(), cr.localPosition().y(),
+                                   cr.size().x() / 2.0, cr.size().y() / 2.0,
+                                   cr.diskID()});
             }
         }
     }
@@ -403,18 +406,22 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         ymax = std::max(ymax, pos.y() + dy);
     }
 
-    double crystalSizeX = disk.crystal(0).size().x();
-    double crystalSizeY = disk.crystal(0).size().y();
-    int nbinsX = std::max(1, (int)std::round((xmax - xmin) / crystalSizeX));
-    int nbinsY = std::max(1, (int)std::round((ymax - ymin) / crystalSizeY));
-    TH2F* energyHist = new TH2F("calo_disk_energy", "Calorimeter Disk 0;X (mm);Y (mm)", nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+    TH2Poly* energyHist = new TH2Poly("calo_disk_energy",
+                                      "Calorimeter Disk 0 - Hit Energy Deposition;X (mm);Y (mm)",
+                                      xmin, xmax, ymin, ymax);
     energyHist->SetDirectory(0);
     energyHist->SetStats(0);
     gStyle->SetPalette(kBird);
     energyHist->GetZaxis()->SetTitle("edep (MeV)");
 
-    for (const auto& h : allHits)
-        if (h.diskID == 0) energyHist->Fill(h.cx, h.cy, h.eDep);
+    // Add one poly bin per hit crystal so empty crystals stay white (background).
+    std::set<int> addedD0;
+    for (const auto& h : allHits) {
+        if (h.diskID != 0) continue;
+        if (addedD0.insert(h.crystalID).second)
+            energyHist->AddBin(h.cx - h.dx, h.cy - h.dy, h.cx + h.dx, h.cy + h.dy);
+        energyHist->Fill(h.cx, h.cy, h.eDep);
+    }
 
     energyHist->Draw("COLZ");
 
@@ -439,7 +446,8 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         g->SetMarkerStyle(20);
         g->SetMarkerSize(0.5);
         g->SetMarkerColorAlpha(kWhite, 0);
-        g->SetName(Form("Crystal %d  time=%.2f ns  eDep=%.2f MeV", h.crystalID, h.time, h.eDep));
+        g->SetName(Form("calo_hit_%d", h.crystalID));
+        g->SetTitle(Form("CrystalID %d  time=%.2f ns  eDep=%.3f MeV", h.crystalID, h.time, h.eDep));
         g->Draw("P SAME");
     }
 
@@ -469,20 +477,21 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         ymax1 = std::max(ymax1, pos.y() + dy);
     }
 
-    double crystalSizeX1 = disk1.crystal(0).size().x();
-    double crystalSizeY1 = disk1.crystal(0).size().y();
-    int nbinsX1 = std::max(1, (int)std::round((xmax1 - xmin1) / crystalSizeX1));
-    int nbinsY1 = std::max(1, (int)std::round((ymax1 - ymin1) / crystalSizeY1));
-    TH2F* energyHist1 = new TH2F("calo_disk1_energy",
-                                   "Calorimeter Disk 1 - Hit Energy Deposition;X (mm);Y (mm)",
-                                   nbinsX1, xmin1, xmax1, nbinsY1, ymin1, ymax1);
+    TH2Poly* energyHist1 = new TH2Poly("calo_disk1_energy",
+                                       "Calorimeter Disk 1 - Hit Energy Deposition;X (mm);Y (mm)",
+                                       xmin1, xmax1, ymin1, ymax1);
     energyHist1->SetDirectory(0);
     energyHist1->SetStats(0);
     gStyle->SetPalette(kBird);
     energyHist1->GetZaxis()->SetTitle("edep (MeV)");
 
-    for (const auto& h : allHits)
-        if (h.diskID == 1) energyHist1->Fill(h.cx, h.cy, h.eDep);
+    std::set<int> addedD1;
+    for (const auto& h : allHits) {
+        if (h.diskID != 1) continue;
+        if (addedD1.insert(h.crystalID).second)
+            energyHist1->AddBin(h.cx - h.dx, h.cy - h.dy, h.cx + h.dx, h.cy + h.dy);
+        energyHist1->Fill(h.cx, h.cy, h.eDep);
+    }
 
     energyHist1->Draw("COLZ");
 

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -387,7 +387,7 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     const mu2e::Disk& disk = calo->disk(0);
 
     if (!fCaloCanvas)
-        fCaloCanvas = new TCanvas("calo_disk", "Calorimeter Disk 0", 1400, 1200);
+        fCaloCanvas = new TCanvas("calo_disk0_canvas", "Disk 0", 1400, 1200);
     fCaloCanvas->cd();
     fCaloCanvas->Clear();
     fCaloCanvas->SetRightMargin(0.15);
@@ -406,12 +406,11 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         ymax = std::max(ymax, pos.y() + dy);
     }
 
-    TH2Poly* energyHist = new TH2Poly("calo_disk_energy",
-                                      "Calorimeter Disk 0 - Hit Energy Deposition;X (mm);Y (mm)",
-                                      xmin, xmax, ymin, ymax);
+    TH2Poly* energyHist = new TH2Poly("calo_disk0", "Disk 0;X (mm);Y (mm)", xmin, xmax, ymin, ymax);
     energyHist->SetDirectory(0);
     energyHist->SetStats(0);
     gStyle->SetPalette(kBird);
+    energyHist->GetZaxis()->SetTitleOffset(1.5);
     energyHist->GetZaxis()->SetTitle("edep (MeV)");
 
     // Add one poly bin per hit crystal so empty crystals stay white (background).
@@ -446,8 +445,7 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         g->SetMarkerStyle(20);
         g->SetMarkerSize(0.5);
         g->SetMarkerColorAlpha(kWhite, 0);
-        g->SetName(Form("calo_hit_%d", h.crystalID));
-        g->SetTitle(Form("CrystalID %d  time=%.2f ns  eDep=%.3f MeV", h.crystalID, h.time, h.eDep));
+        g->SetName(Form("Crystal %d  time=%.2f ns  eDep=%.2f MeV", h.crystalID, h.time, h.eDep));
         g->Draw("P SAME");
     }
 
@@ -458,7 +456,7 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     const mu2e::Disk& disk1 = calo->disk(1);
 
     if (!fCaloCanvas1)
-        fCaloCanvas1 = new TCanvas("calo_disk1", "Calorimeter Disk 1", 1400, 1200);
+        fCaloCanvas1 = new TCanvas("calo_disk1_canvas", "Disk 1", 1400, 1200);
     fCaloCanvas1->cd();
     fCaloCanvas1->Clear();
     fCaloCanvas1->SetRightMargin(0.15);
@@ -477,12 +475,11 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         ymax1 = std::max(ymax1, pos.y() + dy);
     }
 
-    TH2Poly* energyHist1 = new TH2Poly("calo_disk1_energy",
-                                       "Calorimeter Disk 1 - Hit Energy Deposition;X (mm);Y (mm)",
-                                       xmin1, xmax1, ymin1, ymax1);
+    TH2Poly* energyHist1 = new TH2Poly("calo_disk1","Disk 1;X (mm);Y (mm)", xmin1, xmax1, ymin1, ymax1);
     energyHist1->SetDirectory(0);
     energyHist1->SetStats(0);
     gStyle->SetPalette(kBird);
+    energyHist1->GetZaxis()->SetTitleOffset(1.5);
     energyHist1->GetZaxis()->SetTitle("edep (MeV)");
 
     std::set<int> addedD1;
@@ -516,8 +513,7 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         g->SetMarkerStyle(20);
         g->SetMarkerSize(0.5);
         g->SetMarkerColorAlpha(kWhite, 0);
-        g->SetName(Form("calo_hit_%d", h.crystalID));
-        g->SetTitle(Form("CrystalID %d  time=%.2f ns  eDep=%.3f MeV", h.crystalID, h.time, h.eDep));
+        g->SetName(Form("Crystal %d  time=%.2f ns  eDep=%.2f MeV", h.crystalID, h.time, h.eDep));
         g->Draw("P SAME");
     }
 

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -365,6 +365,22 @@ void TrackerCalo2DViews::drawTrackerXYView(const mu2e::KalSeedPtrCollection* see
 
 void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* clustercol) {
     mu2e::GeomHandle<mu2e::DiskCalorimeter> calo;
+
+    // Collect per-hit data from cluster hit vectors
+    struct HitInfo { int crystalID; float time; float eDep; double cx; double cy; int diskID; };
+    std::vector<HitInfo> allHits;
+    if (clustercol != nullptr) {
+        for (const auto& cluster : *clustercol) {
+            for (const auto& hitPtr : cluster.caloHitsPtrVector()) {
+                const mu2e::CaloHit& hit = *hitPtr;
+                const mu2e::Crystal& cr  = calo->crystal(hit.crystalID());
+                allHits.push_back({hit.crystalID(), hit.time(), hit.energyDep(),
+                                   cr.localPosition().x(), cr.localPosition().y(), cr.diskID()});
+            }
+        }
+    }
+
+    // --- Disk 0 ---
     const mu2e::Disk& disk = calo->disk(0);
 
     if (!fCaloCanvas)
@@ -373,7 +389,6 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     fCaloCanvas->Clear();
     fCaloCanvas->SetRightMargin(0.15);
 
-    // Compute exact crystal grid extent — no margin so bin edges align with crystal edges
     double xmin =  1e9, xmax = -1e9;
     double ymin =  1e9, ymax = -1e9;
     for (size_t icr = 0; icr < disk.nCrystals(); ++icr) {
@@ -388,31 +403,23 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         ymax = std::max(ymax, pos.y() + dy);
     }
 
-    // One bin per crystal: Fill() at any COG inside a crystal lands in exactly that crystal's bin
     double crystalSizeX = disk.crystal(0).size().x();
     double crystalSizeY = disk.crystal(0).size().y();
     int nbinsX = std::max(1, (int)std::round((xmax - xmin) / crystalSizeX));
     int nbinsY = std::max(1, (int)std::round((ymax - ymin) / crystalSizeY));
     TH2F* energyHist = new TH2F("calo_disk_energy",
-                                 "Calorimeter Disk 0 - Cluster Energy Deposition;X (mm);Y (mm)",
+                                 "Calorimeter Disk 0 - Hit Energy Deposition;X (mm);Y (mm)",
                                  nbinsX, xmin, xmax, nbinsY, ymin, ymax);
     energyHist->SetDirectory(0);
     energyHist->SetStats(0);
     gStyle->SetPalette(kBird);
     energyHist->GetZaxis()->SetTitle("edep (MeV)");
 
-    // cog3Vector() x,y are in the same frame as crystal.localPosition() x,y
-    if (clustercol != nullptr) {
-        for (const auto& cluster : *clustercol) {
-            if (cluster.diskID() != 0) continue;
-            CLHEP::Hep3Vector cog = cluster.cog3Vector();
-            energyHist->Fill(cog.x(), cog.y(), cluster.energyDep());
-        }
-    }
+    for (const auto& h : allHits)
+        if (h.diskID == 0) energyHist->Fill(h.cx, h.cy, h.eDep);
 
     energyHist->Draw("COLZ");
 
-    // Draw crystal outlines on top of the energy map
     for (size_t icr = 0; icr < disk.nCrystals(); ++icr) {
         const mu2e::Crystal& crystal = disk.crystal(icr);
         CLHEP::Hep3Vector pos  = crystal.localPosition();
@@ -426,6 +433,17 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         box->SetLineColor(kGray + 1);
         box->SetLineWidth(1);
         box->Draw();
+    }
+
+    for (const auto& h : allHits) {
+        if (h.diskID != 0) continue;
+        TGraph* g = new TGraph(1, &h.cx, &h.cy);
+        g->SetMarkerStyle(20);
+        g->SetMarkerSize(0.5);
+        g->SetMarkerColorAlpha(kWhite, 0);
+        g->SetName(Form("calo_hit_%d", h.crystalID));
+        g->SetTitle(Form("CrystalID %d  time=%.2f ns  eDep=%.3f MeV", h.crystalID, h.time, h.eDep));
+        g->Draw("P SAME");
     }
 
     fCaloCanvas->Modified();
@@ -459,20 +477,15 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     int nbinsX1 = std::max(1, (int)std::round((xmax1 - xmin1) / crystalSizeX1));
     int nbinsY1 = std::max(1, (int)std::round((ymax1 - ymin1) / crystalSizeY1));
     TH2F* energyHist1 = new TH2F("calo_disk1_energy",
-                                   "Calorimeter Disk 1 - Cluster Energy Deposition;X (mm);Y (mm)",
+                                   "Calorimeter Disk 1 - Hit Energy Deposition;X (mm);Y (mm)",
                                    nbinsX1, xmin1, xmax1, nbinsY1, ymin1, ymax1);
     energyHist1->SetDirectory(0);
     energyHist1->SetStats(0);
     gStyle->SetPalette(kBird);
     energyHist1->GetZaxis()->SetTitle("edep (MeV)");
 
-    if (clustercol != nullptr) {
-        for (const auto& cluster : *clustercol) {
-            if (cluster.diskID() != 1) continue;
-            CLHEP::Hep3Vector cog = cluster.cog3Vector();
-            energyHist1->Fill(cog.x(), cog.y(), cluster.energyDep());
-        }
-    }
+    for (const auto& h : allHits)
+        if (h.diskID == 1) energyHist1->Fill(h.cx, h.cy, h.eDep);
 
     energyHist1->Draw("COLZ");
 
@@ -489,6 +502,17 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         box->SetLineColor(kGray + 1);
         box->SetLineWidth(1);
         box->Draw();
+    }
+
+    for (const auto& h : allHits) {
+        if (h.diskID != 1) continue;
+        TGraph* g = new TGraph(1, &h.cx, &h.cy);
+        g->SetMarkerStyle(20);
+        g->SetMarkerSize(0.5);
+        g->SetMarkerColorAlpha(kWhite, 0);
+        g->SetName(Form("calo_hit_%d", h.crystalID));
+        g->SetTitle(Form("CrystalID %d  time=%.2f ns  eDep=%.3f MeV", h.crystalID, h.time, h.eDep));
+        g->Draw("P SAME");
     }
 
     fCaloCanvas1->Modified();

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -399,15 +399,18 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     energyHist->SetDirectory(0);
     energyHist->SetStats(0);
     gStyle->SetPalette(kBird);
-    energyHist->GetZaxis()->SetTitle("Energy Deposition (MeV)");
+    energyHist->GetZaxis()->SetTitle("edep (MeV)");
 
     // Fill from disk-0 clusters using their COG projected to disk-local frame
     if (clustercol != nullptr) {
+      
         for (const auto& cluster : *clustercol) {
             if (cluster.diskID() != 0) continue;
             CLHEP::Hep3Vector cog = cluster.cog3Vector();
-            CLHEP::Hep3Vector localPos = calo->geomUtil().mu2eToDisk(0, cog);
-            energyHist->Fill(localPos.x(), localPos.y(), cluster.energyDep());
+            std::cout<<"COG = "<<cog.x()<<"  "<<cog.y()<<std::endl; 
+            //CLHEP::Hep3Vector localPos = calo->geomUtil().mu2eToDisk(0, cog);
+            energyHist->Fill(cog.x(), cog.y(), cluster.energyDep());
+            //std::cout<<"Calo Cluster Crystal position = "<<localPos.x()<<"  "<<localPos.y()<<" energy dep = "<<cluster.energyDep()<<std::endl;
         }
     }
 

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -8,6 +8,7 @@
 #include <TLatex.h>
 #include <TGraph.h>
 #include <TLegend.h>
+#include <TStyle.h>
 #include <TBufferJSON.h>
 #include <TBase64.h>
 #include <algorithm>
@@ -24,6 +25,7 @@
 #include "Offline/CalorimeterGeom/inc/DiskCalorimeter.hh"
 #include "Offline/CalorimeterGeom/inc/Disk.hh"
 #include "Offline/CalorimeterGeom/inc/Crystal.hh"
+#include "Offline/RecoDataProducts/inc/CaloCluster.hh"
 
 namespace mu2e {
 
@@ -361,17 +363,17 @@ void TrackerCalo2DViews::drawTrackerXYView(const mu2e::KalSeedPtrCollection* see
     fXYCanvas->Update();
 }
 
-void TrackerCalo2DViews::drawCalorimeterDisk() {
+void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* clustercol) {
     mu2e::GeomHandle<mu2e::DiskCalorimeter> calo;
     const mu2e::Disk& disk = calo->disk(0);
 
     if (!fCaloCanvas)
-        fCaloCanvas = new TCanvas("calo_disk", "Calorimeter Disk 0", 1200, 1200);
+        fCaloCanvas = new TCanvas("calo_disk", "Calorimeter Disk 0", 1400, 1200);
     fCaloCanvas->cd();
     fCaloCanvas->Clear();
-    gPad->SetFixedAspectRatio();
+    fCaloCanvas->SetRightMargin(0.15);
 
-    // Compute crystal bounds to set frame range
+    // Compute crystal bounds to set histogram range
     double xmin =  1e9, xmax = -1e9;
     double ymin =  1e9, ymax = -1e9;
     for (size_t icr = 0; icr < disk.nCrystals(); ++icr) {
@@ -386,13 +388,32 @@ void TrackerCalo2DViews::drawCalorimeterDisk() {
         ymax = std::max(ymax, pos.y() + dy);
     }
     double margin = 20.0;
-    TH2F* frame = new TH2F("calo_disk_frame", "Calorimeter Disk 0;X (mm);Y (mm)",
-                            100, xmin - margin, xmax + margin,
-                            100, ymin - margin, ymax + margin);
-    frame->SetDirectory(0);
-    frame->SetStats(0);
-    frame->Draw();
+    xmin -= margin; xmax += margin;
+    ymin -= margin; ymax += margin;
 
+    // 2D histogram: X-Y are disk-local crystal coordinates, fill weight = energyDep (MeV)
+    // 200x200 bins gives ~7 mm/bin, finer than a crystal (~33 mm) so COG fills the right cell
+    TH2F* energyHist = new TH2F("calo_disk_energy",
+                                 "Calorimeter Disk 0 - Cluster Energy Deposition;X (mm);Y (mm)",
+                                 200, xmin, xmax, 200, ymin, ymax);
+    energyHist->SetDirectory(0);
+    energyHist->SetStats(0);
+    gStyle->SetPalette(kBird);
+    energyHist->GetZaxis()->SetTitle("Energy Deposition (MeV)");
+
+    // Fill from disk-0 clusters using their COG projected to disk-local frame
+    if (clustercol != nullptr) {
+        for (const auto& cluster : *clustercol) {
+            if (cluster.diskID() != 0) continue;
+            CLHEP::Hep3Vector cog = cluster.cog3Vector();
+            CLHEP::Hep3Vector localPos = calo->geomUtil().mu2eToDisk(0, cog);
+            energyHist->Fill(localPos.x(), localPos.y(), cluster.energyDep());
+        }
+    }
+
+    energyHist->Draw("COLZ");
+
+    // Draw crystal outlines on top of the energy map
     for (size_t icr = 0; icr < disk.nCrystals(); ++icr) {
         const mu2e::Crystal& crystal = disk.crystal(icr);
         CLHEP::Hep3Vector pos  = crystal.localPosition();
@@ -403,7 +424,7 @@ void TrackerCalo2DViews::drawCalorimeterDisk() {
         double dy = size.y() / 2.0;
         TBox* box = new TBox(x - dx, y - dy, x + dx, y + dy);
         box->SetFillStyle(0);
-        box->SetLineColor(kBlue + 1);
+        box->SetLineColor(kGray + 1);
         box->SetLineWidth(1);
         box->Draw();
     }

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -391,11 +391,14 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     xmin -= margin; xmax += margin;
     ymin -= margin; ymax += margin;
 
-    // 2D histogram: X-Y are disk-local crystal coordinates, fill weight = energyDep (MeV)
-    // 200x200 bins gives ~7 mm/bin, finer than a crystal (~33 mm) so COG fills the right cell
+    // Bin size = crystal face size so one Fill() at the COG covers the full crystal cell
+    double crystalSizeX = disk.crystal(0).size().x();
+    double crystalSizeY = disk.crystal(0).size().y();
+    int nbinsX = std::max(1, (int)std::round((xmax - xmin) / crystalSizeX));
+    int nbinsY = std::max(1, (int)std::round((ymax - ymin) / crystalSizeY));
     TH2F* energyHist = new TH2F("calo_disk_energy",
                                  "Calorimeter Disk 0 - Cluster Energy Deposition;X (mm);Y (mm)",
-                                 200, xmin, xmax, 200, ymin, ymax);
+                                 nbinsX, xmin, xmax, nbinsY, ymin, ymax);
     energyHist->SetDirectory(0);
     energyHist->SetStats(0);
     gStyle->SetPalette(kBird);
@@ -457,9 +460,13 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     xmin1 -= margin; xmax1 += margin;
     ymin1 -= margin; ymax1 += margin;
 
+    double crystalSizeX1 = disk1.crystal(0).size().x();
+    double crystalSizeY1 = disk1.crystal(0).size().y();
+    int nbinsX1 = std::max(1, (int)std::round((xmax1 - xmin1) / crystalSizeX1));
+    int nbinsY1 = std::max(1, (int)std::round((ymax1 - ymin1) / crystalSizeY1));
     TH2F* energyHist1 = new TH2F("calo_disk1_energy",
                                    "Calorimeter Disk 1 - Cluster Energy Deposition;X (mm);Y (mm)",
-                                   200, xmin1, xmax1, 200, ymin1, ymax1);
+                                   nbinsX1, xmin1, xmax1, nbinsY1, ymin1, ymax1);
     energyHist1->SetDirectory(0);
     energyHist1->SetStats(0);
     gStyle->SetPalette(kBird);

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -373,7 +373,7 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     fCaloCanvas->Clear();
     fCaloCanvas->SetRightMargin(0.15);
 
-    // Compute crystal bounds to set histogram range
+    // Compute exact crystal grid extent — no margin so bin edges align with crystal edges
     double xmin =  1e9, xmax = -1e9;
     double ymin =  1e9, ymax = -1e9;
     for (size_t icr = 0; icr < disk.nCrystals(); ++icr) {
@@ -387,11 +387,8 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         ymin = std::min(ymin, pos.y() - dy);
         ymax = std::max(ymax, pos.y() + dy);
     }
-    double margin = 20.0;
-    xmin -= margin; xmax += margin;
-    ymin -= margin; ymax += margin;
 
-    // Bin size = crystal face size so one Fill() at the COG covers the full crystal cell
+    // One bin per crystal: Fill() at any COG inside a crystal lands in exactly that crystal's bin
     double crystalSizeX = disk.crystal(0).size().x();
     double crystalSizeY = disk.crystal(0).size().y();
     int nbinsX = std::max(1, (int)std::round((xmax - xmin) / crystalSizeX));
@@ -404,9 +401,8 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
     gStyle->SetPalette(kBird);
     energyHist->GetZaxis()->SetTitle("edep (MeV)");
 
-    // Fill from disk-0 clusters using their COG projected to disk-local frame
+    // cog3Vector() x,y are in the same frame as crystal.localPosition() x,y
     if (clustercol != nullptr) {
-      
         for (const auto& cluster : *clustercol) {
             if (cluster.diskID() != 0) continue;
             CLHEP::Hep3Vector cog = cluster.cog3Vector();
@@ -457,8 +453,6 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
         ymin1 = std::min(ymin1, pos.y() - dy);
         ymax1 = std::max(ymax1, pos.y() + dy);
     }
-    xmin1 -= margin; xmax1 += margin;
-    ymin1 -= margin; ymax1 += margin;
 
     double crystalSizeX1 = disk1.crystal(0).size().x();
     double crystalSizeY1 = disk1.crystal(0).size().y();

--- a/src/TrackerCalo2DViews.cc
+++ b/src/TrackerCalo2DViews.cc
@@ -434,6 +434,68 @@ void TrackerCalo2DViews::drawCalorimeterDisk(const CaloClusterCollection* cluste
 
     fCaloCanvas->Modified();
     fCaloCanvas->Update();
+
+    // --- Disk 1 ---
+    const mu2e::Disk& disk1 = calo->disk(1);
+
+    if (!fCaloCanvas1)
+        fCaloCanvas1 = new TCanvas("calo_disk1", "Calorimeter Disk 1", 1400, 1200);
+    fCaloCanvas1->cd();
+    fCaloCanvas1->Clear();
+    fCaloCanvas1->SetRightMargin(0.15);
+
+    double xmin1 =  1e9, xmax1 = -1e9;
+    double ymin1 =  1e9, ymax1 = -1e9;
+    for (size_t icr = 0; icr < disk1.nCrystals(); ++icr) {
+        const mu2e::Crystal& crystal = disk1.crystal(icr);
+        CLHEP::Hep3Vector pos  = crystal.localPosition();
+        CLHEP::Hep3Vector size = crystal.size();
+        double dx = size.x() / 2.0;
+        double dy = size.y() / 2.0;
+        xmin1 = std::min(xmin1, pos.x() - dx);
+        xmax1 = std::max(xmax1, pos.x() + dx);
+        ymin1 = std::min(ymin1, pos.y() - dy);
+        ymax1 = std::max(ymax1, pos.y() + dy);
+    }
+    xmin1 -= margin; xmax1 += margin;
+    ymin1 -= margin; ymax1 += margin;
+
+    TH2F* energyHist1 = new TH2F("calo_disk1_energy",
+                                   "Calorimeter Disk 1 - Cluster Energy Deposition;X (mm);Y (mm)",
+                                   200, xmin1, xmax1, 200, ymin1, ymax1);
+    energyHist1->SetDirectory(0);
+    energyHist1->SetStats(0);
+    gStyle->SetPalette(kBird);
+    energyHist1->GetZaxis()->SetTitle("Energy Deposition (MeV)");
+
+    if (clustercol != nullptr) {
+        for (const auto& cluster : *clustercol) {
+            if (cluster.diskID() != 1) continue;
+            CLHEP::Hep3Vector cog = cluster.cog3Vector();
+            CLHEP::Hep3Vector localPos = calo->geomUtil().mu2eToDisk(1, cog);
+            energyHist1->Fill(localPos.x(), localPos.y(), cluster.energyDep());
+        }
+    }
+
+    energyHist1->Draw("COLZ");
+
+    for (size_t icr = 0; icr < disk1.nCrystals(); ++icr) {
+        const mu2e::Crystal& crystal = disk1.crystal(icr);
+        CLHEP::Hep3Vector pos  = crystal.localPosition();
+        CLHEP::Hep3Vector size = crystal.size();
+        double x  = pos.x();
+        double y  = pos.y();
+        double dx = size.x() / 2.0;
+        double dy = size.y() / 2.0;
+        TBox* box = new TBox(x - dx, y - dy, x + dx, y + dy);
+        box->SetFillStyle(0);
+        box->SetLineColor(kGray + 1);
+        box->SetLineWidth(1);
+        box->Draw();
+    }
+
+    fCaloCanvas1->Modified();
+    fCaloCanvas1->Update();
 }
 
   /*void TrackerCalo2DViews::redrawCanvas(const mu2e::KalSeedPtrCollection* seedcol) {


### PR DESCRIPTION
Y v/s X view with 3D histogram showing edep. 

Right click on the calorimeter hit to obtain crystal ID, time and edep info
<img width="1374" height="1145" alt="Screenshot 2026-05-14 at 12 44 15" src="https://github.com/user-attachments/assets/fd75583c-00bb-4bcb-8356-e706002db677" />
[calo_disk0_canvas.pdf](https://github.com/user-attachments/files/27771265/calo_disk0_canvas.pdf)
[calo_disk1_canvas.pdf](https://github.com/user-attachments/files/27771270/calo_disk1_canvas.pdf)
[calo_disk0_event946.pdf](https://github.com/user-attachments/files/27771281/calo_disk0_event946.pdf)
