### PR TITLE
show ComboHits, not TrkStrawHits, in extracted

### DIFF
--- a/examples/extracted_MDC2025.fcl
+++ b/examples/extracted_MDC2025.fcl
@@ -46,7 +46,8 @@ physics.analyzers.Mu2eEventDisplay.filler.addCrvRecoPulse : false
 physics.analyzers.Mu2eEventDisplay.filler.addCaloDigis : false
 physics.analyzers.Mu2eEventDisplay.filler.addClusters : true
 physics.analyzers.Mu2eEventDisplay.filler.addKalSeeds : true
-physics.analyzers.Mu2eEventDisplay.filler.addTrackerHist : true
+physics.analyzers.Mu2eEventDisplay.addTrkStrawHits : false
+physics.analyzers.Mu2eEventDisplay.filler.addHits : true
 physics.analyzers.Mu2eEventDisplay.filler.addCaloHist : false
 physics.analyzers.Mu2eEventDisplay.extracted : true
 physics.analyzers.Mu2eEventDisplay.specifyTag : false


### PR DESCRIPTION
Simple tweak. This relies on Production https://github.com/Mu2e/Production/pull/548